### PR TITLE
Fixed usage of wrong callback data format in test and Callback class

### DIFF
--- a/src/Callback.php
+++ b/src/Callback.php
@@ -196,7 +196,7 @@ class Callback
         $data = $this->data;
         $signature = $this->getSignature();
         $this->removeParam('signature', $data);
-        return $this->signatureHandler->check($data['body'], $signature);
+        return $this->signatureHandler->check($data, $signature);
     }
 
     /**

--- a/tests/data/callback.php
+++ b/tests/data/callback.php
@@ -1,11 +1,9 @@
 <?php
 
 $callback = [
-    'body' => [
-        'payment' => [
-            'id' => '000049',
-            'status' => 'success',
-        ],
+    'payment' => [
+        'id' => '000049',
+        'status' => 'success',
     ],
     'signature' => '/3TrhHVz9BHaLfgLyhoxO7dsQNzbzZa/TdO3pxQocXWwgVM6tGlzMLVfpOxFNTnkR9iiFVK/77ZedMcbkCjmng==',
 ];


### PR DESCRIPTION
На данный момент ecommpay присылает callback в котором сигнатура лежит в одном месте с остальными параметрами, не существует объекта со свойством body в ответе.